### PR TITLE
Fix load_metric deprecated

### DIFF
--- a/run_summarization.py
+++ b/run_summarization.py
@@ -27,7 +27,8 @@ from typing import Optional
 import datasets
 import nltk  # Here to have a nice missing dependency error message early on
 import numpy as np
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
+import evaluate
 
 import transformers
 from filelock import FileLock
@@ -570,7 +571,7 @@ def main():
     )
 
     # Metric
-    metric = load_metric("cer")
+    metric = evaluate.load("cer")
 
     def postprocess_text(preds, labels):
         preds = [pred.strip() for pred in preds]


### PR DESCRIPTION
FutureWarning: load_metric is deprecated and will be removed in the next major version of datasets. Use 'evaluate.load' instead, from the new library. Evaluate: https://huggingface.co/docs/evaluate